### PR TITLE
Feature/extend checker links

### DIFF
--- a/lang/en/block_course_checker.php
+++ b/lang/en/block_course_checker.php
@@ -128,6 +128,7 @@ $string['checker_links_ok'] =
         '{$a->url} is valid (Code {$a->http_code})'; // You can get any curl info or pare_url field in $a.
 $string['checker_links_error_skipped'] = 'The domain {$a->host} is whitelisted for {$a->url}';
 $string['checker_links_error_undefined'] = 'A undefined error with the link occurred';
+$string['checker_links_error_httpsecurity'] = 'The given domain {$a} is blacklisted by checking its address and port number against the black/white lists in Moodle HTTP security.';
 $string['checker_links_setting_timeout'] = 'cURL timeout';
 $string['checker_links_setting_connect_timeout'] = 'cURL connection timeout';
 $string['checker_links_setting_useragent'] = 'User Agent';

--- a/locallib.php
+++ b/locallib.php
@@ -105,13 +105,15 @@ function user_has_given_role_in_course($userid, $courseid, $roles) {
 /**
  * Check one domain whether it is valid.
  * - Extended to allow HTTP/HTTPS protocol.
+ * - Extended to allow optional port.
+ * - Extended to allow URL paths.
  * Taken from https://stackoverflow.com/a/4694816
  *
  * @param $domainname
  * @return bool
  */
 function is_valid_domain_name($domainname) {
-    return (1 === preg_match("/^((http|https:\/\/)?[a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $domainname) // Valid chars.
+    return (1 === preg_match("/^((http[s]?:\/\/)?[a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*(?::\d+)?(\/[a-z\d.]*)*$/i", $domainname) // Valid chars.
             && 1 === preg_match("/^.{1,253}$/", $domainname) // Overall length check.
             && 1 === preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domainname)); // Length of each label.
 }


### PR DESCRIPTION
## Summary
This will help to improve the `checker_links` to enable port and path ins the whitelist of the domains.

### Closes issue(s)
- #39 

### Replication steps
- Go to `Site administration > Plugins > Blocks > Course checker`
- Search for setting `checker_links_whitelist`
- Input a domain name with a path, e.g. `https://moodle.org/course/`
- It should accept this entry now.
- Then go to `Course C`
- Create a `Label` activity and input some test links
- Run `checker_links` check
- Verify result looks similar to the image in the `appendix`

### Changelog
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [x] I have tested this code
- [ ] I have updated the Readme

### Appendix
![image](https://user-images.githubusercontent.com/9467708/86357721-8f033d00-bc6e-11ea-8143-4f46ab2ff66c.png)
